### PR TITLE
feat: allow passing Hono instance to `create` fn

### DIFF
--- a/.changeset/three-readers-doubt.md
+++ b/.changeset/three-readers-doubt.md
@@ -1,0 +1,5 @@
+---
+"opencontrol": minor
+---
+
+allow passing Hono instance to create fn

--- a/packages/opencontrol/src/index.ts
+++ b/packages/opencontrol/src/index.ts
@@ -18,6 +18,7 @@ export interface OpenControlOptions {
   tools: Tool[]
   password?: string
   model?: LanguageModelV1
+  app?: Hono
 }
 
 export type App = ReturnType<typeof create>
@@ -30,7 +31,8 @@ export function create(input: OpenControlOptions) {
     process.env.OPENCONTROL_KEY ||
     "password"
   console.log("opencontrol password:", token)
-  return new Hono()
+  const app = input.app ?? new Hono()
+  return app
     .use(
       cors({
         origin: "*",


### PR DESCRIPTION
Allows passing `Hono` instance to `create` function

```ts
const hono = new Hono();

hono.use(logger())

const app = create(
  model,
  tools: [dbReadonlyAccessTool],
  app: hono,
)
```