### PR TITLE
Fix zod version incompatibility

### DIFF
--- a/packages/opencontrol/package.json
+++ b/packages/opencontrol/package.json
@@ -26,11 +26,10 @@
     "@tsconfig/bun": "1.0.7",
     "ai": "4.2.11",
     "hono": "4.11.4",
-    "zod": "4.2.1",
-    "zod-to-json-schema": "3.25.0"
+    "zod": "4.2.1"
   },
   "devDependencies": {
-    "@standard-schema/spec": "1.0.0",
+    "@standard-schema/spec": "1.1.0",
     "opencontrol-frontend": "workspace:*"
   }
 }

--- a/packages/opencontrol/src/mcp.ts
+++ b/packages/opencontrol/src/mcp.ts
@@ -10,7 +10,6 @@ import {
 } from "@modelcontextprotocol/sdk/types.js"
 import { z } from "zod"
 import { Tool } from "./tool.js"
-import { zodToJsonSchema } from "zod-to-json-schema"
 
 const RequestSchema = z.union([
   InitializeRequestSchema,
@@ -41,10 +40,11 @@ export function createMcp(input: { tools: Tool[] }) {
           return {
             tools: input.tools.map((tool) => ({
               name: tool.name,
-              inputSchema: zodToJsonSchema(
-                tool.args || (z.object({}) as any),
-                "args",
-              ).definitions!["args"] as any,
+              inputSchema: (tool.args
+                ? tool.args["~standard"].jsonSchema.input({
+                    target: "draft-2020-12",
+                  })
+                : { type: "object" }) as { type: "object" },
               description: tool.description,
             })),
           } satisfies ListToolsResult

--- a/packages/opencontrol/src/tool.ts
+++ b/packages/opencontrol/src/tool.ts
@@ -1,20 +1,18 @@
-import { StandardSchemaV1 } from "@standard-schema/spec"
+import { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
 import { z } from "zod"
 
-export interface Tool<
-  Args extends undefined | StandardSchemaV1 = undefined | StandardSchemaV1,
-> {
+type Schema = StandardSchemaV1 & StandardJSONSchemaV1
+
+export interface Tool<Args extends undefined | Schema = undefined | Schema> {
   name: string
   description: string
   args?: Args
-  run: Args extends StandardSchemaV1
+  run: Args extends Schema
     ? (args: StandardSchemaV1.InferOutput<Args>) => Promise<any>
     : () => Promise<any>
 }
 
-export function tool<Args extends undefined | StandardSchemaV1>(
-  input: Tool<Args>,
-) {
+export function tool<Args extends undefined | Schema>(input: Tool<Args>) {
   return input
 }
 


### PR DESCRIPTION
merging #49 caused [type errors](https://github.com/anomalyco/opencontrol/actions/runs/21224934046) because of the new Zod version being incompatible with `@hono/zod-validator`

this prevented the release of the new OpenControl version which is needed to fix the vulnerability issue in SST

<details>

<summary>proof of it working</summary>

<img width="1542" height="1450" alt="CleanShot 2026-01-22 at 12 51 24@2x" src="https://github.com/user-attachments/assets/d4a91803-b886-4576-a722-e2a3746c2c17" />

<img width="1472" height="352" alt="CleanShot 2026-01-22 at 17 51 58@2x" src="https://github.com/user-attachments/assets/e5d79145-a34f-4e02-8ad8-e426b48c17e9" />

</details>